### PR TITLE
Add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,5 +52,6 @@
   "resolutions": {
     "@babel/preset-env": "7.13.8"
   },
-  "keywords": []
+  "keywords": [],
+  "license": "MIT"
 }


### PR DESCRIPTION
We rely on tools to detect licenses used in dependencies: https://www.npmjs.com/package/license-compliance , and they rely on this field. 